### PR TITLE
Fix/date-query

### DIFF
--- a/src/db/permanent/models/snapshot.js
+++ b/src/db/permanent/models/snapshot.js
@@ -105,10 +105,10 @@ const applyFilter = (qs, filter) => {
     });
   }
   if (filter && filter.dateCreatedFrom) {
-    qs.where('dateCreated', '>=', new Date(filter.dateCreatedFrom).getTime());
+    qs.where('dateCreated', '>=', new Date(filter.dateCreatedFrom));
   }
   if (filter && filter.dateCreatedTo) {
-    qs.where('dateCreated', '<', new Date(filter.dateCreatedTo).getTime());
+    qs.where('dateCreated', '<', new Date(filter.dateCreatedTo));
   }
   if (filter && filter.segments) {
     qs.where('segments', 'like', `%${filter.segments}%`);


### PR DESCRIPTION
Request using time columns like 
`https://explorer-cache.myorgid.com/organizations?segment=HOTELS&dateCreatedFrom=2019-01-01&dateCreatedTo=2019-09-08` throws `#500` because, query to db, throws `error: date/time field value out of range: `. This only happen with PostgreSQL, but not with SQLite.
Removing `.getTime()` fixes the issue